### PR TITLE
create parent directory of bujo if needed

### DIFF
--- a/plugin/bujo.vim
+++ b/plugin/bujo.vim
@@ -8,7 +8,7 @@ let g:bujo#window_width = get(g:, "bujo#window_width", 30)
 
 " Make bujo directory if it doesn't exist"
 if empty(glob(g:bujo#todo_file_path))
-  call mkdir(g:bujo#todo_file_path)
+  call mkdir(g:bujo#todo_file_path, 'p')
 endif
 
 " InGitRepository() tells us if the directory we are currently working in


### PR DESCRIPTION
Fixes  error 
```
Error detected while processing $HOME/.vim/plugged/vim-bujo/plugin/bujo.vim:
line   11:
E739: Cannot create directory: $HOME/.cache/bujo
```